### PR TITLE
[command]Added feature to remove role from server when empty

### DIFF
--- a/bot/commands/coderoles/add.py
+++ b/bot/commands/coderoles/add.py
@@ -8,7 +8,7 @@ class cmd(Command):
 
     ### Allowed languages and max allowed code roles per user ###
     code_roles_color = Color.from_rgb(137, 204, 240)
-    max_code = 3
+    max_code = 5
     whitelist = [
         "Ada",
         "Assembly",

--- a/bot/commands/coderoles/remove.py
+++ b/bot/commands/coderoles/remove.py
@@ -31,6 +31,9 @@ class cmd(Command):
         # Removes role from user
         role = Code.getRole(self,message, arguments[0])
         await message.author.remove_roles(role)
+        # Removes role from server if role is empty
+        if len(role.members) == 0:
+            await role.delete()
         embed = Embed(
             title="Code", description=f"**`{name}` has been removed from the `{role.name}` code role.**")
         await message.channel.send(embed=embed)

--- a/bot/commands/distroroles/leaderboard.py
+++ b/bot/commands/distroroles/leaderboard.py
@@ -19,7 +19,7 @@ class cmd(Command):
         description = "**Leaderboard:**\n\n"
         # Checks current distro roles in server
         for role in server_roles_names:
-            if role in Distro.whitelist and len(Code.getRole(self, message, role).members) > 0:
+            if role in Distro.whitelist and len(Distro.getRole(self, message, role).members) > 0:
                 leaderboard.append({"role": role, "count": len(Distro.getRole(self,message,role).members)})
         # Returns if there are no distro roles
         if leaderboard == []:

--- a/bot/commands/distroroles/remove.py
+++ b/bot/commands/distroroles/remove.py
@@ -31,6 +31,9 @@ class cmd(Command):
         # Removes role from user
         role = Distro.getRole(self,message, arguments[0])
         await message.author.remove_roles(role)
+        # Removes role from server if role is empty
+        if len(role.members) == 0:
+            await role.delete()
         embed = Embed(
             title="Distro", description=f"**`{name}` has been removed from the `{role.name}` distro role.**")
         await message.channel.send(embed=embed)


### PR DESCRIPTION
**What kind of change does this PR introduce?**  
Fix bug where incorrect variable was left in distro leaderboard command,
Added feature to remove distro/code roles from server when empty

**What is the current behavior?**  
distro leaderboard breaks because wrong variable is referenced, distro/code roles remain active on server even when empty

**What is the new behavior**  
Fixes distro leaderboard, and now code/distro roles are deleted when they have 0 members

**Does this PR introduce a breaking change?**  
No

