### PR TITLE
remove case sensitivity in distro and code commands

### DIFF
--- a/bot/commands/coderoles/add.py
+++ b/bot/commands/coderoles/add.py
@@ -78,20 +78,14 @@ class cmd(Command):
         for role in message.guild.roles:
             server_roles_names.append(role.name)
 
-        # Checks if role exists ignoring capitalization
-        if arguments[0] in (i.lower() for i in self.whitelist if (guess := i).lower() == arguments[0]):
-            embed = Embed(title="Code", description=f"**Invalid language**\nDid you mean to type ``{guess}`` ? \n\n*To see valid languages, use:*\n`v!code whitelist`")
-            embed.set_color("red")
-            await message.channel.send(embed=embed)
-            return
         # Checks if role is whitelisted
-        if arguments[0] not in self.whitelist:
+        if arguments[0].lower() not in map(lambda lang: lang.lower(), self.whitelist):
             embed = Embed(title="Code", description="**Invalid language**\n\n*To see valid languages, use:*\n`v!code whitelist`")
             embed.set_color("red")
             await message.channel.send(embed=embed)
             return
         # Checks if user already has the role
-        if arguments[0] in user_roles_names:
+        if arguments[0].lower() in map(lambda role: role.lower(), user_roles_names):
             embed = Embed(title="Code", description=f"**`{name}` already has that code role**")
             embed.set_color("red")
             await message.channel.send(embed=embed)
@@ -106,11 +100,15 @@ class cmd(Command):
             embed.set_color("red")
             await message.channel.send(embed=embed)
             return
+
+        role_name = self.whitelist[
+                list(map(lambda lang: lang.lower(), self.whitelist)).index(arguments[0].lower())
+        ]
         # Checks if role exists, if not, creates role
-        if arguments[0] not in server_roles_names:
-            await message.guild.create_role(name=arguments[0], mentionable=True, colour=self.code_roles_color)
+        if role_name not in server_roles_names:
+            await message.guild.create_role(name=role_name, mentionable=True, colour=self.code_roles_color)
         # Adds user to role
-        role = self.getRole(message, arguments[0])
+        role = self.getRole(message, role_name)
         await message.author.add_roles(role)
         embed = Embed(title="Code", description=f"**`{name}` has been added to the `{role.name}` code role**")
         await message.channel.send(embed=embed)

--- a/bot/commands/coderoles/remove.py
+++ b/bot/commands/coderoles/remove.py
@@ -16,20 +16,18 @@ class cmd(Command):
         for role in message.author.roles:
             user_roles_names.append(role.name)
             
-        # Checks if role exists ignoring capitalization
-        if arguments[0] not in Code.whitelist and arguments[0] in (i.lower() for i in Code.whitelist if (guess := i).lower() == arguments[0]) and guess in user_roles_names:
-            embed = Embed(title="Code", description=f"**Invalid language**\nDid you mean to type ``{guess}`` ? \n\n*To see valid languages, use:*\n`v!code whitelist`")
-            embed.set_color("red")
-            await message.channel.send(embed=embed)
-            return
         # Checks if user has role and role is whitelisted
-        if arguments[0] not in Code.whitelist or arguments[0] not in user_roles_names:
+        if arguments[0].lower() not in map(lambda lang: lang.lower(), Code.whitelist) or arguments[0].lower() not in map(lambda role: role.lower(), user_roles_names):
             embed = Embed(title="Code", description=f"**`{name}` does not have that code role, or `{arguments[0]}` is not whitelisted**\n\n*To your see current code roles, use:* \n`v!code roles`\n\n*To see whitelisted languages, use:*\n`v!code whitelist`")
             embed.set_color("red")
             await message.channel.send(embed=embed)
             return
+
+        role_name = Code.whitelist[
+                list(map(lambda lang: lang.lower(), Code.whitelist)).index(arguments[0].lower())
+        ]
         # Removes role from user
-        role = Code.getRole(self,message, arguments[0])
+        role = Code.getRole(self,message, role_name)
         await message.author.remove_roles(role)
         # Removes role from server if role is empty
         if len(role.members) == 0:

--- a/bot/commands/distroroles/add.py
+++ b/bot/commands/distroroles/add.py
@@ -56,6 +56,7 @@ class cmd(Command):
         'TrueNAS',
         'Ubuntu',
         'Ultramarine',
+        'UwUntu',
         'Void',
         'Whonix',
         'Windows',
@@ -82,20 +83,14 @@ class cmd(Command):
         for role in message.guild.roles:
             server_roles_names.append(role.name)
 
-        # Checks if role exists ignoring capitalization
-        if arguments[0] in (i.lower() for i in self.whitelist if (guess := i).lower() == arguments[0]):
-            embed = Embed(title="Distro", description=f"**Invalid distro**\nDid you mean to type ``{guess}`` ? \n\n*To see valid distros, use:*\n`v!distro whitelist`")
-            embed.set_color("red")
-            await message.channel.send(embed=embed)
-            return
         # Checks if role is whitelisted
-        if arguments[0] not in self.whitelist:
+        if arguments[0].lower() not in map(lambda distro: distro.lower(), self.whitelist):
             embed = Embed(title="Distro", description="**Invalid distro**\n\n*To see valid distros, use:*\n`v!distro whitelist`")
             embed.set_color("red")
             await message.channel.send(embed=embed)
             return
         # Checks if user already has the role
-        if arguments[0] in user_roles_names:
+        if arguments[0].lower() in map(lambda role: role.lower(), user_roles_names):
             embed = Embed(title="Distro", description=f"**`{name}` already has that distro role**")
             embed.set_color("red")
             await message.channel.send(embed=embed)
@@ -110,11 +105,15 @@ class cmd(Command):
             embed.set_color("red")
             await message.channel.send(embed=embed)
             return
+
+        role_name = self.whitelist[
+                list(map(lambda distro: distro.lower(), self.whitelist)).index(arguments[0].lower())
+        ]
         # Checks if role exists, if not, creates role
-        if arguments[0] not in server_roles_names:
-            await message.guild.create_role(name=arguments[0], mentionable=True, colour=self.distro_roles_color)
+        if role_name not in server_roles_names:
+            await message.guild.create_role(name=role_name, mentionable=True, colour=self.distro_roles_color)
         # Adds user to role
-        role = self.getRole(message, arguments[0])
+        role = self.getRole(message, role_name)
         await message.author.add_roles(role)
         embed = Embed(title="Distro", description=f"**`{name}` has been added to the `{role.name}` distro role**")
         await message.channel.send(embed=embed)

--- a/bot/commands/distroroles/remove.py
+++ b/bot/commands/distroroles/remove.py
@@ -16,20 +16,18 @@ class cmd(Command):
         for role in message.author.roles:
             user_roles_names.append(role.name)
             
-        # Checks if role exists ignoring capitalization
-        if arguments[0] not in Distro.whitelist and arguments[0] in (i.lower() for i in Distro.whitelist if (guess := i).lower() == arguments[0]) and guess in user_roles_names:
-            embed = Embed(title="Distro", description=f"**Invalid distro**\nDid you mean to type ``{guess}`` ? \n\n*To see valid distros, use:*\n`v!distro whitelist`")
-            embed.set_color("red")
-            await message.channel.send(embed=embed)
-            return
         # Checks if user has role and role is whitelisted
-        if arguments[0] not in Distro.whitelist or arguments[0] not in user_roles_names:
+        if arguments[0].lower() not in map(lambda distro: distro.lower(), Distro.whitelist) or arguments[0].lower() not in map(lambda role: role.lower(), user_roles_names):
             embed = Embed(title="Distro", description=f"**`{name}` does not have that distro role, or `{arguments[0]}` is not whitelisted**\n\n*To your see current distro roles, use:* \n`v!distro roles`\n\n*To see whitelisted distro roles, use:*\n`v!distro whitelist`")
             embed.set_color("red")
             await message.channel.send(embed=embed)
             return
+
+        role_name = Distro.whitelist[
+                list(map(lambda distro: distro.lower(), Distro.whitelist)).index(arguments[0].lower())
+        ]
         # Removes role from user
-        role = Distro.getRole(self,message, arguments[0])
+        role = Distro.getRole(self,message, role_name)
         await message.author.remove_roles(role)
         # Removes role from server if role is empty
         if len(role.members) == 0:


### PR DESCRIPTION
**What kind of change does this PR introduce?**  
feature

**Describe the changes proposed in the pull request**  
the PR makes the `distro` and `code` commands case-insensitive

**What is the current behavior?**  
if the user inputs a role name with incorrect capitalization, the bot suggests a role with correct caps

**What is the new behavior**  
the functions are now case-insensitive

**Does this PR introduce a breaking change?**  
i don't think so

**Other information:**  
also added `UwUntu` to distros
