### PR TITLE
Escape '*' symbol in calc command

### DIFF
--- a/bot/commands/calc.py
+++ b/bot/commands/calc.py
@@ -154,6 +154,10 @@ class cmd(Command):
         # Get the result.
         result = calculator.expr()
         
+        expression = expression.translate(
+            str.maketrans({ "*": "\\*" })
+        ) # escape '*' characters in expression
+        
         # Send the result:
         await message.channel.send(f"_{expression}_ = **{result:g}**")
         


### PR DESCRIPTION
If you write a command like "v!calc 2\*2\*2" bot will answer "2*2*2 = **8**".
I escaped the "*" symbol.

 2*2*2 = **8**
 \>\>\>
  2\*2\*2 = **8**