### PR TITLE
python does leave comma as empty string

### DIFF
--- a/bot/config.py
+++ b/bot/config.py
@@ -59,7 +59,7 @@ class Config:
         os.getenv("DISCOX_REPORT_ID", 1064539181193375784)
     )  # mod role id
     mod_role_id: List[int] = [
-        int(x) for x in os.getenv("DISCOX_MOD_ROLE_ID", "0,").split(",")
+        int(x) for x in os.getenv("DISCOX_MOD_ROLE_ID", "0").split(",")
     ]  # mod role id
     temp_channel: int = int(os.getenv("DISCOX_TEMP_CHANNEL", "0"))  # temp channel id
     channel_id: str = os.getenv(


### PR DESCRIPTION
**What kind of change does this PR introduce?**  
Bug fix

**Describe the changes proposed in the pull request**  
Python leaves comma as blank string so int function will error it out

**What is the current behavior?**  
Python throws error on no .env configured

**What is the new behavior**  
This shouldn't make python complains about empty string and try convert it to integer

**Does this PR introduce a breaking change?**  
None

**Other information:**  

