### PR TITLE
Quickfix For Minesweeper

### DIFF
--- a/bot/commands/games/minesweeper.py
+++ b/bot/commands/games/minesweeper.py
@@ -147,6 +147,7 @@ class MineBoard(discord.ui.View):
         self.remaining_tiles -= 1
         if button.near_mines > 0:
             button.label = button.near_mines
+            return
         while not q.empty():
             current = q.get()
             for butt in current.neighbors:


### PR DESCRIPTION
Added a return statement in the clear surroundings to prevent clearing if the button pushed is near a mine

