### PR TITLE
[fix] always check `before.channel`

### DIFF
--- a/bot/events/on_voice_state.py
+++ b/bot/events/on_voice_state.py
@@ -8,6 +8,8 @@ class event(Event):
     name = "on_voice_state_update"
 
     async def execute(self, member, before, after) -> None:
+        if "Voice Channel #" in before.channel.name and len(before.channel.members) == 0:
+            await before.channel.delete(reason="Empty channel")
         if after.channel is not None and "Create VC" in after.channel.name:
             category = after.channel.category
             if len(category.voice_channels) > 6:
@@ -18,9 +20,3 @@ class event(Event):
                     f"Voice Channel #{len(category.voice_channels)}"
                 )
                 await member.move_to(channel, reason="Created private channel")
-
-        elif (
-            "Voice Channel #" in before.channel.name
-            and len(before.channel.members) == 0
-        ):
-            await before.channel.delete(reason="Empty channel")


### PR DESCRIPTION
**What kind of change does this PR introduce?**  
Bug fix

**Describe the changes proposed in the pull request**  
Fixed the bug that occurs when moving to "Create VC" from "Voice Channel #x"

**What is the current behavior?**  
Bot doesn't delete the previous channel when moving to "Create VC"

**What is the new behavior**  
Bot always check the previous channel.

**Does this PR introduce a breaking change?**  
No

**Does this PR introduce changes to the database?**
No

**Other information:** None


