### PR TITLE
Fixed regex not match with parameter-less URLs

### DIFF
--- a/bot/events/reaction_add.py
+++ b/bot/events/reaction_add.py
@@ -10,7 +10,7 @@ class event(Event):
     name = "on_raw_reaction_add"
 
     async def execute(self, payload) -> None:
-        IMAGE_REGEX = "http(s)?:([\/|.|\w|\s]|-)*\.(?:jpg|gif|png|jpeg)\?.*[^\s]"
+        IMAGE_REGEX = "http(s)?:([\/|.|\w|\s]|-)*\.(?:jpg|gif|png|jpeg)(\?(.[^\s]*))?"
         REACTION = "⭐"
         starboard = await self.bot.fetch_channel(Config.starboard_channel)
         if not payload.emoji.name == REACTION:


### PR DESCRIPTION
**What kind of change does this PR introduce?**  
Bug fix

**What is the current behavior?**  
Bot can't detect URLs with no parameters.

**What is the new behavior**  
Bot detects URLs with no parameters.

**Does this PR introduce a breaking change?**  
No

**Does this PR introduce changes to the database?**
No

**Other information:** None


