### PR TITLE
Handle if there is an internal server error that sends 200 response code

### DIFF
--- a/bot/commands/distroroles/info.py
+++ b/bot/commands/distroroles/info.py
@@ -19,30 +19,23 @@ class cmd(Command):
     description = "Shows information about the user entered distro"
 
     async def execute(self, arguments, message) -> None:
+        error_embed = Embed(
+            title="Distro",
+            description=f"**Not found**\n\nThe distro named `{arguments[0]}` not found."
+        )
+        error_embed.set_color("red")
+
         async with aiohttp.ClientSession() as session:
             async with session.get(
                 f"https://diwa.demo-web-fahmi.my.id/api/v2/distributions/{arguments[0]}"
             ) as result:
-                j = None
-                try:
-                    j = await result.json(loads=orjson.loads)
-                except:
-                    embed = Embed(
-                        title="Distro",
-                        description=f"**Not found**\n\nThe distro named `{arguments[0]}` not found.",
-                    )
-            embed.set_color("red")
-            await message.channel.send(embed=embed)
+                if result.status != 200:
+                    await message.channel.send(embed=error_embed)
+                    return
+                j = await result.json(loads=orjson.loads)
+        if j["message"] != "success":
+            await message.channel.send(embed=error_embed)
             return
-        if not j or result.status != 200 or j["message"] != "success":
-            embed = Embed(
-                title="Distro",
-                description=f"**Not found**\n\nThe distro named `{arguments[0]}` not found.",
-            )
-            embed.set_color("red")
-            await message.channel.send(embed=embed)
-            return
-
         dominant_color = None
         distro_codename = None
         try:

--- a/bot/commands/distroroles/info.py
+++ b/bot/commands/distroroles/info.py
@@ -23,8 +23,18 @@ class cmd(Command):
             async with session.get(
                 f"https://diwa.demo-web-fahmi.my.id/api/v2/distributions/{arguments[0]}"
             ) as result:
-                j = await result.json(loads=orjson.loads)
-        if result.status != 200 or j["message"] != "success":
+                j = None
+                try:
+                    j = await result.json(loads=orjson.loads)
+                except:
+                    embed = Embed(
+                        title="Distro",
+                        description=f"**Not found**\n\nThe distro named `{arguments[0]}` not found.",
+                    )
+            embed.set_color("red")
+            await message.channel.send(embed=embed)
+            return
+        if not j or result.status != 200 or j["message"] != "success":
             embed = Embed(
                 title="Distro",
                 description=f"**Not found**\n\nThe distro named `{arguments[0]}` not found.",


### PR DESCRIPTION
**What kind of change does this PR introduce?**  
Bug fix

**What is the current behavior?**  
Bot sends an unhandled error if the API sends internal server error with 200 response.

**What is the new behavior**  
Bot handles that and simply sends a distro not found error

**Does this PR introduce a breaking change?**  
No

**Does this PR introduce changes to the database?**
No

**Other information:** None

