### PR TITLE
since manager is for typing why not wrap it in TYPE_CHECKING

### DIFF
--- a/bot/base.py
+++ b/bot/base.py
@@ -12,8 +12,10 @@ from discord.ext import tasks
 from .logger import Logger
 from .sql import SQLParser
 
-# from .manager import Manager
-Manager = None  # FIX: circular imports :'((
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .manager import Manager
 
 
 # @dataclass

--- a/bot/base.py
+++ b/bot/base.py
@@ -17,7 +17,6 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from .manager import Manager
 
-
 # @dataclass
 class Command(ABC):
     """Base abstract class for all commands."""
@@ -32,7 +31,7 @@ class Command(ABC):
     db: Optional[SQLParser] = None
     logger = Logger()
 
-    def __init__(self, bot: discord.Client, manager: Manager, db: SQLParser) -> None:
+    def __init__(self, bot: discord.Client, manager: "Manager", db: SQLParser) -> None:
         """Initialize the command.
 
         [Args]:
@@ -123,7 +122,7 @@ class Event(ABC):
     db: Optional[SQLParser] = None
     logger = Logger()
 
-    def __init__(self, bot: discord.Client, manager: Manager, db: SQLParser) -> None:
+    def __init__(self, bot: discord.Client, manager: "Manager", db: SQLParser) -> None:
         """Initialize the command.
 
         [Args]:
@@ -161,7 +160,7 @@ class Task(ABC):
     db: Optional[SQLParser] = None
     logger = Logger()
 
-    def __init__(self, bot: discord.Client, manager: Manager, db: SQLParser) -> None:
+    def __init__(self, bot: discord.Client, manager: "Manager", db: SQLParser) -> None:
         """Initialize the task.
 
         [Args]:


### PR DESCRIPTION
**What kind of change does this PR introduce?**  
Update

**Describe the changes proposed in the pull request**  
A typing for Manager class is now added to the base. Should works without seeing circular imports

**What is the current behavior?**  
If you import module directly it will error with circular import

**What is the new behavior**  
wrapping it in TYPE_CHECKING will import it at checking its type not the runtime

**Does this PR introduce a breaking change?**  
Nope

**Does this PR introduce changes to the database?**
Nope

**Other information:** 
Nope

