### PR TITLE
Fix discord send limit from 4K to 2K

### DIFF
--- a/bot/commands/fun/gen_spam.py
+++ b/bot/commands/fun/gen_spam.py
@@ -95,9 +95,10 @@ class cmd(Command):
     def literal_spam(self, string: str):
         # Generate spam till the end of the universe (message length limit)
         output = ""
-        for x in range(0, 4000):
+        spam_len_limit = 2000
+        for x in range(0, spam_len_limit):
             output += string
-        output = output[:4000]
+        output = output[:spam_len_limit]
         return output
 
     async def execute(self, arguments, message) -> None:


### PR DESCRIPTION
I just forgot that the discord send limit if 2K even for bots (I though I saw 4K in discox error message somewhere)