### PR TITLE
Better chop in literal_spam

### DIFF
--- a/bot/commands/fun/gen_spam.py
+++ b/bot/commands/fun/gen_spam.py
@@ -96,9 +96,25 @@ class cmd(Command):
         # Generate spam till the end of the universe (message length limit)
         output = ""
         spam_len_limit = 2000
+        final_chop = spam_len_limit
+        chop_case = [' ', '<', '>', '\n']  # Order of the elements determine final chop, first checks first
+
         for x in range(0, spam_len_limit):
             output += string
+
+        # early chop to work with less stuff in next step
         output = output[:spam_len_limit]
+
+        # version 1:
+        #return output
+
+        # Chop at the last character that matched with ordered chop_case
+        for x in range(spam_len_limit - 1, 0, -1):
+            if output[x] in chop_case:
+                final_chop = x
+                break
+
+        output = output[:final_chop]
         return output
 
     async def execute(self, arguments, message) -> None:


### PR DESCRIPTION
**What kind of change does this PR introduce?**  
Bug fix, feature

**Describe the changes proposed in the pull request**  
Chop in a more intelligent way, instead of chopping in the end of spam limit, it will chop a bit earlier where it meets the final character that is either a space, left/right angle bracket (for emojis), or a new line (just in case)

**What is the current behavior?**  
Chops at the end of discord send limit, which when spammed with emojis, ends up with half emoji strings that discord uses to recognize.

**What is the new behavior**  
Exactly prevents the above

**Does this PR introduce a breaking change?**  
There may not be any breaking changes but, we need more chop cases and it is good idea to let the users test them
