### PR TITLE
Handle boost messages on starboard

### DIFF
--- a/bot/events/on_raw_reaction_add.py
+++ b/bot/events/on_raw_reaction_add.py
@@ -104,6 +104,8 @@ class event(Event):
 
                     if messageObj.content:
                         embed.description = messageObj.content
+                    elif "MessageType.premium_guild" in str(messageObj.type):
+                        embed.description = f"{messageObj.author} boosted the server :sunglasses:"
                     if len(messageObj.attachments) != 0:
                         if "image" in messageObj.attachments[0].content_type:
                             embed.set_image(url=messageObj.attachments[0].url)


### PR DESCRIPTION
**What kind of change does this PR introduce?**  
Feature

**Describe the changes proposed in the pull request**  
Added message content to boost messages.

**What is the current behavior?**  
Boost messages doesn't have a content so boost messages on starboard looks empty.

**What is the new behavior**  
Boost messages are now handled and the message content is `<booster> boosted the server 😎`.

**Does this PR introduce a breaking change?**  
No

**Does this PR introduce changes to the database?**
No

**Other information:** None


