### PR TITLE
Add LMDE to distro roles

### DIFF
--- a/bot/commands/distroroles/add.py
+++ b/bot/commands/distroroles/add.py
@@ -37,6 +37,7 @@ class DistroRoles(Roles):
         "Kali",
         "Kubuntu",
         "LineageOS",
+        "LMDE",
         "Lubuntu",
         "MacOS",
         "Manjaro",


### PR DESCRIPTION
Added Linux Mint Debian edition to distro roles. I use it myself and it just felt weird that it was missing. Shouldn't break anything.


