### PR TITLE
Remove Discord username discriminators

### DIFF
--- a/bot/__main__.py
+++ b/bot/__main__.py
@@ -331,7 +331,7 @@ def main() -> None:
         logger.log(f"Logged in as {bot.user}")
 
         logger.newline()
-        logger.log("Username:", f"{bot.user.name}#{bot.user.discriminator}")
+        logger.log("Username:", f"{bot.user.name}")
         logger.log("ID:", f"{bot.user.id}")
         logger.log("Guilds:", f"{len(bot.guilds)}")
         logger.log("Prefix:", config.prefix)

--- a/bot/commands/levels/rank.py
+++ b/bot/commands/levels/rank.py
@@ -79,7 +79,7 @@ class cmd(Command):
                     user_xp=result[0],
                     next_xp=result[1] * 25 + 100,
                     server_position=rank,
-                    user_name=f"Unrenderable Username#{user.discriminator}",  # weird ass mf username
+                    user_name=f"Unrenderable Username",  # weird ass mf username
                     user_status=str(user.status),
                     font_color=await self.get_font_color(user.id),
                 )

--- a/bot/commands/reminders/list.py
+++ b/bot/commands/reminders/list.py
@@ -17,7 +17,7 @@ class cmd(Command):
             (message.author.id,),
         )
         embed = Embed(
-            title=f"Reminders of {message.author.name}#{message.author.discriminator}"
+            title=f"Reminders of {message.author.name}"
         )
         for reminder in reminders:
             timestamp, remindMsg = reminder

--- a/bot/commands/request/request.py
+++ b/bot/commands/request/request.py
@@ -62,12 +62,10 @@ class cmd(Command):
         # MAIN EXECUTION: after getting all the information, the bot will add all of the information to the database
         split_member_id = member_id.split(" ")
         member_name = split_member_id[2].replace("'", "")[5:]
-        member_discriminator = split_member_id[3].replace("'", "")[14:]
-        member_id = member_name + "#" + member_discriminator
 
         await self.db.raw_exec_commit(
             "INSERT INTO request(Member_id, Title, Description, Upvote, Downvote, Pending_close) VALUES(?, ?, ?, ?, ?, ?)",
-            (member_id, title.content, description.content, 0, 0, 0),
+            (member_name, title.content, description.content, 0, 0, 0),
         )
         # Notify the user that the bot has added the request to the database.
         embed = Embed(title="A request has been added!")


### PR DESCRIPTION
**What kind of change does this PR introduce?**  
Bug fix

**Describe the changes proposed in the pull request**  
Removed references to user and bot discriminators

**What is the current behavior?**  
In some instances where the bot displays a user's name and discriminator, the user's discriminator is displayed as "#0" if the user has one of the new usernames without the discriminator.

**What is the new behavior**  
All explicit references to discriminators are removed entirely, except for stuff depending on discord.py I guess. 

**Does this PR introduce a breaking change?**  
No

**Does this PR introduce changes to the database?**
Not really, besides using `member_name` over `member_id` in line 70 (now 68) of bot/commands/request/request.py

**Other information:** 
I don't know python or discord.py very well so let me know if something needs to be changed, or if there are any more references to discriminators that I missed.