### PR TITLE
Automate Active Member

### DIFF
--- a/bot/events/on_message.py
+++ b/bot/events/on_message.py
@@ -38,11 +38,11 @@ class event(Event):
                             await message.author.add_roles(
                                     role
                                 )
-                            # Congradulates user :D
-                            await message.channel.send(
-                                    f"Congratulations {message.author.mention}, you are now a {role.mention}!"
-                                    )
                             break
+                    # Congradulates user :D
+                    await message.channel.send(
+                            f"Congratulations {message.author.mention}, you are now an {role_name}!"
+                            )
                     
                 result = await self.db.raw_exec_select(
                     f"SELECT exp, level FROM levels WHERE user_id = '{message.author.id}'"

--- a/bot/events/on_message.py
+++ b/bot/events/on_message.py
@@ -38,6 +38,25 @@ class event(Event):
                         "UPDATE levels SET level = ?, exp = ? WHERE user_id = ?",
                         (result[0][1], result[0][0] + 1, message.author.id),
                     )
+                    # Checks if user is an active member
+                    if result[0][1] >= 3:
+                        active_member_name = "Active Member"
+                        active_member_color = discord.Color.blue()
+                        # Checks if role already exits, if not, creates it
+                        if active_member_name not in [
+                            x.name.lower() for x in message.guild.roles
+                        ]:
+                            await message.guild.create_role(
+                                name=active_member_name, colour=active_member_color
+                            )
+
+                        # Adds user to active member role
+                        for role in message.guild.roles:
+                            if role.name.lower() == active_member_name.lower():
+                                await message.author.add_roles(
+                                    role               
+                                )
+                                break
 
                     if result[0][0] + 1 >= result[0][1] * 25 + 100:
                         await self.db.raw_exec_commit(

--- a/bot/events/on_message.py
+++ b/bot/events/on_message.py
@@ -38,11 +38,11 @@ class event(Event):
                             await message.author.add_roles(
                                     role
                                 )
+                            # Congradulates user :D
+                            await message.channel.send(
+                                    f"Congratulations {message.author.mention}, you are now a {role.mention}!"
+                                    )
                             break
-                    # Congradulates user :D
-                    await message.channel.send(
-                            f"Congratulations {message.author.mention}, you are now an {role_name}!"
-                            )
                     
                 result = await self.db.raw_exec_select(
                     f"SELECT exp, level FROM levels WHERE user_id = '{message.author.id}'"

--- a/bot/events/on_message.py
+++ b/bot/events/on_message.py
@@ -59,6 +59,10 @@ class event(Event):
                         "UPDATE levels SET level = ?, exp = ? WHERE user_id = ?",
                         (result[0][1], result[0][0] + 1, message.author.id),
                     )
+                    # Add user to member role on first message
+                    if result [0][0] == 0 and result[0][1] == 0:
+                        await addToRole(message, "Member", discord.Color.dark_teal())                          
+
                     if result[0][0] + 1 >= result[0][1] * 25 + 100:
                         await self.db.raw_exec_commit(
                             "UPDATE levels SET level = ?, exp = ? WHERE user_id = ?",

--- a/bot/events/on_message.py
+++ b/bot/events/on_message.py
@@ -59,18 +59,27 @@ class event(Event):
                         "UPDATE levels SET level = ?, exp = ? WHERE user_id = ?",
                         (result[0][1], result[0][0] + 1, message.author.id),
                     )
-                    # Add user to member role on first message
-                    if result [0][0] == 0 and result[0][1] == 0:
-                        await addToRole(message, "Member", discord.Color.dark_teal())                          
+                    # Adds user to member role after first message
+                    if result [0][0] >= 0 and result[0][1] >= 0:
+                        role_name = "Member"
+                        role_color = discord.Color.dark_teal()
+                        # Checks if user has role first
+                        if role_name.lower() not in [x.name.lower() for x in message.author.roles]:
+                            await addToRole(message, role_name, role_color) 
+
+                    # Add user to active member role if level is 3
+                    if result[0][1] >= 3:
+                        role_name = "Active Member"
+                        role_color = discord.Color.blue()
+                        # Checks if user has role first
+                        if role_name.lower() not in [x.name.lower() for x in message.author.roles]:
+                            await addToRole(message, role_name, role_color) 
 
                     if result[0][0] + 1 >= result[0][1] * 25 + 100:
                         await self.db.raw_exec_commit(
                             "UPDATE levels SET level = ?, exp = ? WHERE user_id = ?",
                             (result[0][1] + 1, 0, message.author.id),
                         )
-                        # Add user to active member role if level is 3
-                        if result[0][1] + 1 == 3:
-                            await addToRole(message, "Active Member", discord.Color.blue())                          
                         await message.channel.send(
                             f"Congratulations {message.author.mention}, you just advanced to level {result[0][1] + 1}!"
                         )

--- a/bot/events/on_message.py
+++ b/bot/events/on_message.py
@@ -60,12 +60,11 @@ class event(Event):
                         (result[0][1], result[0][0] + 1, message.author.id),
                     )
                     # Adds user to member role after first message
-                    if result [0][0] >= 0 and result[0][1] >= 0:
-                        role_name = "Member"
-                        role_color = discord.Color.dark_teal()
-                        # Checks if user has role first
-                        if role_name.lower() not in [x.name.lower() for x in message.author.roles]:
-                            await addToRole(message, role_name, role_color) 
+                    role_name = "Member"
+                    role_color = discord.Color.dark_teal()
+                    # Checks if user has role first
+                    if role_name.lower() not in [x.name.lower() for x in message.author.roles]:
+                        await addToRole(message, role_name, role_color) 
 
                     # Add user to active member role if level is 3
                     if result[0][1] >= 3:

--- a/bot/events/on_message.py
+++ b/bot/events/on_message.py
@@ -59,7 +59,7 @@ class event(Event):
                         "UPDATE levels SET level = ?, exp = ? WHERE user_id = ?",
                         (result[0][1], result[0][0] + 1, message.author.id),
                     )
-                    # Adds user to member role after first message
+                    # Adds user to member role if they dont already have it
                     role_name = "Member"
                     role_color = discord.Color.dark_teal()
                     # Checks if user has role first


### PR DESCRIPTION
**What kind of change does this PR introduce?**  
Automates member and active member role 

**Describe the changes proposed in the pull request**  
Added a check at level 3 to assign Active Member Role and on first message for Member role

**What is the current behavior?**  
The roles must be manually assigned 

**What is the new behavior**  
Discox now checks if the user is eligible for the role, and assigns
it to the user they are, on every message. It checks every message to ensure
existing users or those above level 3 are added to the roles as well if they are not
already added. A conditional is put in place to check if the user already has the role first, in order
to prevent overhead and wasted runtime.

**Does this PR introduce a breaking change?**  
Nope

**Does this PR introduce changes to the database?**
Nope


