### PR TITLE
Improvements

### DIFF
--- a/bot/category.py
+++ b/bot/category.py
@@ -173,6 +173,18 @@ class PollsCategory(Category):
     def check_permissions(self, message: discord.Message) -> bool:
         return True
 
+class MinecraftCategory(Category):
+    """A command category instance."""
+
+    name = "minecraft"
+    prefix = "minecraft"
+    commands: List[Command] = []
+
+    def check_permissions(self, message: discord.Message) -> bool:
+        return True
+
+
+
 
 if __name__ == "__main__":
     print(

--- a/bot/commands/minecraft/players.py
+++ b/bot/commands/minecraft/players.py
@@ -1,0 +1,27 @@
+from mcstatus import JavaServer
+
+from bot.base import Command
+from bot.config import Config, Embed
+
+
+class cmd(Command):
+    name = "players"
+    usage = "players"
+    description = "Get the players of the minecraft server"
+
+    async def execute(self, arguments, message) -> None:
+        server = JavaServer.lookup(f"{Config.minecraft_url}:{Config.minecraft_port}")
+# 'query' has to be enabled in a server's server.properties file!
+# It may give more information than a ping, such as a full player list or mod information.
+        query = server.query()
+
+        players = ' \n'.join(query.players.names)
+        embed = Embed(
+            title="Minecraft",
+            description=f"""
+**MAX PLAYERS:** ```{query.players.max}```
+**CURRENT PLAYERS ({query.players.online}):** ```{players}```
+""",
+        )
+        embed.set_color("green")
+        await message.channel.send(embed=embed)

--- a/bot/commands/minecraft/players.py
+++ b/bot/commands/minecraft/players.py
@@ -16,6 +16,8 @@ class cmd(Command):
         query = server.query()
 
         players = ' \n'.join(query.players.names)
+        if len(query.players.names) == 0:
+            players = "Nobody Online :("
         embed = Embed(
             title="Minecraft",
             description=f"""

--- a/bot/commands/minecraft/players.py
+++ b/bot/commands/minecraft/players.py
@@ -19,8 +19,7 @@ class cmd(Command):
         embed = Embed(
             title="Minecraft",
             description=f"""
-**MAX PLAYERS:** ```{query.players.max}```
-**CURRENT PLAYERS ({query.players.online}):** ```{players}```
+**CURRENTLY ONLINE ({query.players.online}/{query.players.max}):** ```{players}```
 """,
         )
         embed.set_color("green")

--- a/bot/commands/minecraft/status.py
+++ b/bot/commands/minecraft/status.py
@@ -21,7 +21,7 @@ class cmd(Command):
             description=f"""
 **URL:** ```{Config.minecraft_url}:{Config.minecraft_port}```
 **VERSION:** ```{query.software.version}({query.software.brand})```
-**PLAYERS:** ```{query.players.online} online```
+**PLAYERS:** ```{query.players.online}/{query.players.max} Online```
 **PLUGINS:** ```{plugins}```
 """,
         )

--- a/bot/commands/minecraft/status.py
+++ b/bot/commands/minecraft/status.py
@@ -5,24 +5,24 @@ from bot.config import Config, Embed
 
 
 class cmd(Command):
-    name = "minecraft"
-    usage = "minecraft"
+    name = "status"
+    usage = "status"
     description = "Get the status of the minecraft server"
 
     async def execute(self, arguments, message) -> None:
         server = JavaServer.lookup(f"{Config.minecraft_url}:{Config.minecraft_port}")
-        status = server.status()
-        if Config.minecraft_port == "25565":
-            url = Config.minecraft_url
-        else:
-            url = f"{Config.minecraft_url}:{Config.minecraft_port}"
+# 'query' has to be enabled in a server's server.properties file!
+# It may give more information than a ping, such as a full player list or mod information.
+        query = server.query()
+
+        plugins = ' \n'.join(query.software.plugins)
         embed = Embed(
             title="Minecraft",
             description=f"""
-**URL:** ```{url}```
-**VERSION:** ```{status.version.name}```
-**MOTD:** ```{status.motd.to_plain()}```
-**CURRENT PLAYERS:** ```{status.players.online}```
+**URL:** ```{Config.minecraft_url}:{Config.minecraft_port}```
+**VERSION:** ```{query.software.version}({query.software.brand})```
+**PLAYERS:** ```{query.players.online} online```
+**PLUGINS:** ```{plugins}```
 """,
         )
         embed.set_color("green")


### PR DESCRIPTION
**What kind of change does this PR introduce?**  
Give the minecraft command its own category, with two subcommands with more verbose information

**Describe the changes proposed in the pull request**  
instead of `v!minecraft` theres is now `v!minecraft status` and `v!minecraft players`
each giving more information the the previous overarching command

**What is the current behavior?**  
The `v!minecraft` only displays very basic information

**What is the new behavior**  
Now the new commands display much more useful info

**Does this PR introduce a breaking change?**  
Nope

**Does this PR introduce changes to the database?**
Nope

**Other information:** 
Use NixOS
