### PR TITLE
Fixed 'an member' instead of 'a member' bug

### DIFF
--- a/bot/events/on_message.py
+++ b/bot/events/on_message.py
@@ -39,7 +39,7 @@ class event(Event):
                             break
                     # Congradulates user :D
                     await message.channel.send(
-                        f"Congratulations {message.author.mention}, you are now {'a' if role_name[0] not in 'aeiou' else 'an'} {role_name}!"
+                        f"Congratulations {message.author.mention}, you are now {'a' if role_name[0].lower() not in 'aeiou' else 'an'} {role_name}!"
                     )
 
                 result = await self.db.raw_exec_select(


### PR DESCRIPTION
The bot used to message "Congratulations {username}! You are now an Member". I have fixed it and now it uses a/an according to the first letter of the role name. Previously the first index of letter was not lowered case and that's why it was not working