### PR TITLE
add qubes os to distro menu

### DIFF
--- a/bot/commands/distroroles/menu.py
+++ b/bot/commands/distroroles/menu.py
@@ -65,6 +65,7 @@ class DistroRoles(RoleView):
         "Parrot",
         "Plasma Mobile",
         "Pop!_OS",
+        "Qubes",
         "Raspbian" "ReactOS",
         "RebornOS",
         "Redcore",


### PR DESCRIPTION
wewduck told me to lol. 

Just added one line to bot/commands/distroroles/menu.py and added qubes to the array

qubes is recognized by distrowatch so any upstream icons should work fine. 
i love qubes os and it is amazing so it is a shame it is not here yet. 

Please merge :O

-tillay8